### PR TITLE
Patched setup.py of tf2onnx for flatbuffers version adjustment

### DIFF
--- a/recipe/0301-Updated-flatbuffers-to-be-1.12.patch
+++ b/recipe/0301-Updated-flatbuffers-to-be-1.12.patch
@@ -1,0 +1,25 @@
+From 9cb41b574a02bc86e5f85ca71291c63c299f7b4d Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Tue, 15 Feb 2022 12:29:30 +0000
+Subject: [PATCH] Updated flatbuffers to be >=1.12
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 27b6382..affec00 100644
+--- a/setup.py
++++ b/setup.py
+@@ -81,7 +81,7 @@ setup(
+     author='onnx@microsoft.com',
+     author_email='onnx@microsoft.com',
+     url='https://github.com/onnx/tensorflow-onnx',
+-    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers~=1.12'],
++    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers>=1.12'],
+     classifiers=[
+         'Development Status :: 5 - Production/Stable',
+         'Intended Audience :: Developers',
+-- 
+2.32.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_url: https://github.com/onnx/tensorflow-onnx/
   git_rev: v{{ version }}
   patches:
-    - 0001-Updated-flatbuffers-to-be-1.12.patch
+    - 0301-Updated-flatbuffers-to-be-1.12.patch
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/onnx/tensorflow-onnx/archive/v{{ version }}.tar.gz
-  sha256: 20244986a2a45b02e66e4e0dd47e24d672e1eb1dce5712447e2456dadb2cc996
+  git_url: https://github.com/onnx/tensorflow-onnx/
+  git_rev: v{{ version }}
+  patches:
+    - 0001-Updated-flatbuffers-to-be-1.12.patch
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Flatbuffers is updated to 2.0 in Open-CE 1.5.2. However, tf2onnx has `flatbuffers ~=1.12` in its setup.py. And this makes `pip check` fail in a conda environment where tf2onnx is installed. To fix this issue, added a patch that will change the version requirement of flatbuffers in tf2onnx.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
